### PR TITLE
allows capmq to be built against non-system installed htslib and zlib 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,12 @@ all: $(PROGS)
 CC=gcc
 
 HTSDIR=../htslib
+HTSSRC=$(HTSDIR)
 
-INCLUDES=-I$(HTSDIR)/include -I$(HTSDIR)
-LIBS=-L$(HTSDIR)/lib -L$(HTSDIR) -lhts -Wl,--rpath,$(HTSDIR)/lib -Wl,--rpath,$(HTSDIR) -lpthread -lz -lm -ldl
+ZLIB_LIBS=-lz
+ZLIB_INCLUDES=
+INCLUDES=-I$(HTSDIR)/include -I$(HTSSRC) $(ZLIB_INCLUDES)
+LIBS=-L$(HTSDIR)/lib -L$(HTSDIR) -lhts -Wl,--rpath,$(HTSDIR)/lib -Wl,--rpath,$(HTSDIR) -lpthread $(ZLIB_LIBS) -lm -ldl
 CFLAGS=-O3 -g -Wall -Werror
 
 PACKAGE_VERSION = 0.3


### PR DESCRIPTION
adds HTSSRC Makefile var to specify location of htslib source (as capmq requires non-public API in `cram/sam_header.h`), separately from HTSDIR which can specify an installed htslib (i.e. for linking/rpath).

adds ZLIB_LIBS and ZLIB_INCLUDES Makefile vars to specify location and linking options for zlib, to facilitate building against a version other than the system installed one. 
